### PR TITLE
Separate out individual languages and pull in bash scripts for Python and dotnet

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,21 @@
 name: 'Pulumi Package publisher'
 description: 'A GitHub Action that publishes provider SDKs'
+inputs:
+  nodejs:
+    description: Publish to npm
+    required: false
+  java:
+    description: Publish to Maven
+    required: false
+  dotnet:
+    description: Publish to Nuget
+    required: false
+  python:
+    description: Publish to PyPI
+    required: false
 runs:
   using: "composite"
   steps:
-    - name: Verify versions
-      run: echo ${{ env.GOVERSION }} &&
-        echo ${{ env.NODEVERSION }} &&
-        echo ${{ env.PYTHONVERSION }}
-      shell: bash
     - name: Checkout Repo
       uses: actions/checkout@v3
       with:
@@ -35,10 +43,41 @@ runs:
       with:
         node-version: ${{ env.NODEVERSION }}
         registry-url: https://registry.npmjs.org
+    - name: Download nodejs SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: nodejs-sdk.tar.gz
+        path: ${{ github.workspace }}/sdk/
+    - name: Uncompress nodejs SDK
+      run: tar -zxf ${{ github.workspace }}/sdk/nodejs.tar.gz -C
+        ${{ github.workspace }}/sdk/nodejs
+      shell: bash
+    - name: Publish Node
+      env:
+        NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
+        NO_TFGEN_PYTHON_PACKAGE: skip-python-publishing
+      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
+      shell: bash
     - name: Setup DotNet
+      if: ${{ inputs.dotnet }}
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.DOTNETVERSION }}
+    - name: Download dotnet SDK
+      uses: actions/download-artifact@v2
+      with:
+        name: dotnet-sdk.tar.gz
+        path: ${{ github.workspace }}/sdk/
+    - name: Uncompress dotnet SDK
+      run: tar -zxf ${{ github.workspace }}/sdk/dotnet.tar.gz -C
+        ${{ github.workspace }}/sdk/dotnet
+      shell: bash
+    - name: Publish nodejs SDK
+      run: if [ -n "${NUGET_PUBLISH_KEY}" ]; then
+        find "${SOURCE_ROOT}/sdk/dotnet/bin/Debug/" -name 'Pulumi.*.nupkg'
+        -exec dotnet nuget push -k "${NUGET_PUBLISH_KEY}" -s https://api.nuget.org/v3/index.json {} ';'
+        fi
+      shell: bash
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
@@ -52,24 +91,23 @@ runs:
       run: tar -zxf ${{ github.workspace }}/sdk/python.tar.gz -C
         ${{ github.workspace }}/sdk/python
       shell: bash
-    - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: dotnet-sdk.tar.gz
-        path: ${{ github.workspace }}/sdk/
-    - name: Uncompress dotnet SDK
-      run: tar -zxf ${{ github.workspace }}/sdk/dotnet.tar.gz -C
-        ${{ github.workspace }}/sdk/dotnet
+    - name: Install Twine
+      run: python -m pip install pip twine
       shell: bash
-    - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
-      with:
-        name: nodejs-sdk.tar.gz
-        path: ${{ github.workspace }}/sdk/
-    - name: Uncompress nodejs SDK
-      run: tar -zxf ${{ github.workspace }}/sdk/nodejs.tar.gz -C
-        ${{ github.workspace }}/sdk/nodejs
+    - name: Publish Python SDK
+      run: if [ -n "${PYPI_USERNAME}" ] ; then
+        PYPI_PUBLISH_USERNAME=${PYPI_USERNAME}
+        else
+        PYPI_PUBLISH_USERNAME="pulumi"
+        fi
+        echo "Publishing Pip package to pypi as ${PYPI_PUBLISH_USERNAME}:"
+        twine upload \
+        -u "${PYPI_PUBLISH_USERNAME}" -p "${PYPI_PASSWORD}" \
+        "${SOURCE_ROOT}/sdk/python/bin/dist/*.tar.gz" \
+        --skip-existing \
+        --verbose
       shell: bash
+
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
@@ -88,14 +126,6 @@ runs:
     - name: Uncompress java SDK
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
-      shell: bash
-    - name: Install Twine
-      run: python -m pip install pip twine
-      shell: bash
-    - name: Publish Node, Python, Dotnet SDKs
-      env:
-        NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
-      run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       shell: bash
     - name: Set PACKAGE_VERSION to Env
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>


### PR DESCRIPTION
We would like to be able to publish only certain language SDKs. This PR is part of the process of separating out the language publishing steps to align by each SDK's prerequisites.
