### PR TITLE
Add inputs logic and usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
 # pulumi-package-publisher
 A composite action for publishing Pulumi packages
+
+_This Action is currently in preview and meant for internal use. Any functionality can and likely will change._
+
+### Purpose
+This Action automates setup and publication to the package registries of four Pulumi languages.
+
+### Setup
+
+Set the following environment variables in your Workflow and your GitHub Action secrets:
+
+```yaml
+env:
+    DOTNETVERSION: |
+    6.0.x
+    3.1.301
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GOVERSION: 1.20.1
+    JAVAVERSION: "11"
+    NODEVERSION: 16.x
+    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+    PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    PYTHONVERSION: "3.9"
+    SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
+    SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
+    SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
+    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    TRAVIS_OS_NAME: linux
+```
+
+### Use
+
+Add this action to your Workflow as a step to publish to all four supported registries:
+- PyPI
+- Maven
+- npm
+- nuget
+
+```yaml
+steps:
+  - name: Publish all SDKs
+    uses: pulumi/pulumi-package-publisher@v0.0.5
+```
+
+Optionally, you may specify language SDKs individually:
+
+```yaml
+steps:
+  - name: Publish nodejs SDK
+    uses: pulumi/pulumi-package-publisher@v0.0.5
+    with:
+      sdk: nodejs
+  - name: Publish Java SDK
+    uses: pulumi/pulumi-package-publisher@v0.0.5
+    with:
+      sdk: java
+  - name: Publish Python SDK
+    uses: pulumi/pulumi-package-publisher@v0.0.5
+    with:
+      sdk: python
+```
+
+Valid inputs to `with.sdk` are:
+
+- `python` - Publish to PyPI
+- `java` - Publish to Maven
+- `nodejs` - Publish to npm
+- `dotnet` - Publish to nuget

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Verify input
-      run: echo 'Publishing SDK:' && echo inputs.sdk
+      run: echo 'Publishing SDK:' && echo ${{ inputs.sdk }}
       shell: bash
     - name: Checkout Repo
       uses: actions/checkout@v3

--- a/action.yml
+++ b/action.yml
@@ -1,21 +1,16 @@
 name: 'Pulumi Package publisher'
 description: 'A GitHub Action that publishes provider SDKs'
 inputs:
-  nodejs:
-    description: Publish to npm
+  sdk:
+    description: The name of the language SDK being published
     required: false
-  java:
-    description: Publish to Maven
-    required: false
-  dotnet:
-    description: Publish to Nuget
-    required: false
-  python:
-    description: Publish to PyPI
-    required: false
+    default: 'all'
 runs:
   using: "composite"
   steps:
+    - name: Verify input
+      run: echo 'Publishing SDK:' && echo inputs.sdk
+      shell: bash
     - name: Checkout Repo
       uses: actions/checkout@v3
       with:
@@ -39,20 +34,24 @@ runs:
     - name: Install Pulumi CLI
       uses: pulumi/action-install-pulumi-cli@v2
     - name: Setup Node
+      if: inputs.sdk == 'nodejs' || inputs.sdk == 'all'
       uses: actions/setup-node@v2
       with:
         node-version: ${{ env.NODEVERSION }}
         registry-url: https://registry.npmjs.org
     - name: Download nodejs SDK
+      if: inputs.sdk == 'nodejs' || inputs.sdk == 'all'
       uses: actions/download-artifact@v2
       with:
         name: nodejs-sdk.tar.gz
         path: ${{ github.workspace }}/sdk/
     - name: Uncompress nodejs SDK
+      if: inputs.sdk == 'nodejs' || inputs.sdk == 'all'
       run: tar -zxf ${{ github.workspace }}/sdk/nodejs.tar.gz -C
         ${{ github.workspace }}/sdk/nodejs
       shell: bash
     - name: Publish Node
+      if: inputs.sdk == 'nodejs' || inputs.sdk == 'all'
       env:
         NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}
         NO_TFGEN_PYTHON_PACKAGE: skip-python-publishing
@@ -60,40 +59,48 @@ runs:
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       shell: bash
     - name: Setup DotNet
-      if: ${{ inputs.dotnet }}
+      if: inputs.sdk == 'dotnet' || inputs.sdk == 'all'
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.DOTNETVERSION }}
     - name: Download dotnet SDK
+      if: inputs.sdk == 'dotnet' || inputs.sdk == 'all'
       uses: actions/download-artifact@v2
       with:
         name: dotnet-sdk.tar.gz
         path: ${{ github.workspace }}/sdk/
     - name: Uncompress dotnet SDK
+      if: inputs.sdk == 'dotnet' || inputs.sdk == 'all'
       run: tar -zxf ${{ github.workspace }}/sdk/dotnet.tar.gz -C
         ${{ github.workspace }}/sdk/dotnet
       shell: bash
     - name: Publish dotnet SDK
+      if: inputs.sdk == 'dotnet' || inputs.sdk == 'all'
       run: find "${{ github.workspace }}/sdk/dotnet/bin/Debug/" -name 'Pulumi.*.nupkg'
         -exec dotnet nuget push -k "${NUGET_PUBLISH_KEY}" -s https://api.nuget.org/v3/index.json {} \;
       shell: bash
     - name: Setup Python
+      if: inputs.sdk == 'python' || inputs.sdk == 'all'
       uses: actions/setup-python@v2
       with:
         python-version: ${{ env.PYTHONVERSION }}
     - name: Download python SDK
+      if: inputs.sdk == 'python' || inputs.sdk == 'all'
       uses: actions/download-artifact@v2
       with:
         name: python-sdk.tar.gz
         path: ${{ github.workspace }}/sdk/
     - name: Uncompress python SDK
+      if: inputs.sdk == 'python' || inputs.sdk == 'all'
       run: tar -zxf ${{ github.workspace }}/sdk/python.tar.gz -C
         ${{ github.workspace }}/sdk/python
       shell: bash
     - name: Install Twine
+      if: inputs.sdk == 'python' || inputs.sdk == 'all'
       run: python -m pip install pip twine
       shell: bash
     - name: Publish Python SDK
+      if: inputs.sdk == 'python' || inputs.sdk == 'all'
       run: if [ -n "${PYPI_USERNAME}" ] ; 
         then PYPI_PUBLISH_USERNAME=${PYPI_USERNAME}; 
         else PYPI_PUBLISH_USERNAME="pulumi";
@@ -106,29 +113,35 @@ runs:
         --verbose
       shell: bash
     - name: Setup Java
+      if: inputs.sdk == 'java' || inputs.sdk == 'all'
       uses: actions/setup-java@v3
       with:
         cache: gradle
         distribution: temurin
         java-version: ${{ env.JAVAVERSION }}
     - name: Setup Gradle
+      if: inputs.sdk == 'java' || inputs.sdk == 'all'
       uses: gradle/gradle-build-action@v2
       with:
         gradle-version: "7.6"
     - name: Download java SDK
+      if: inputs.sdk == 'java' || inputs.sdk == 'all'
       uses: actions/download-artifact@v2
       with:
         name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: Uncompress java SDK
+      if: inputs.sdk == 'java' || inputs.sdk == 'all'
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
       shell: bash
     - name: Set PACKAGE_VERSION to Env
+      if: inputs.sdk == 'java' || inputs.sdk == 'all'
       run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
         $GITHUB_ENV
       shell: bash
     - name: Publish Java SDK
+      if: inputs.sdk == 'java' || inputs.sdk == 'all'
       continue-on-error: true
       uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
       with:


### PR DESCRIPTION
This PR makes this Action fully flexible on an SDK input. Users can now choose to publish to a subset of SDKs, or parallelize their publish steps by calling the action with an SDK input multiple times.

Also adds basic usage documentation for environment variables needed. Notes that this Action is in development and not stable.

EDIT: You can observe a [workflow that only publishes to npm here.](https://github.com/pulumi/pulumi-kafka/actions/runs/4852896413/jobs/8648698461#step:3:61)

- Run steps depending on input value
- Add README
