### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,7 @@ runs:
         ${{ github.workspace }}/sdk/nodejs
       shell: bash
     - name: Run npm whoami
+      if: inputs.sdk == 'nodejs' || inputs.sdk == 'all'
       run: npm whoami
       shell: bash
       env:


### PR DESCRIPTION
Removes an extraneous `npm whoami` from non-nodejs publishing actions. This step fails, as seen in the [logs for pulumi-local]( https://github.com/pulumi/pulumi-local/actions/runs/5284154398/jobs/9561516687#step:3:683) when run with `sdk: dotnet` or `sdk: java`.