### PR TITLE
Publish wheels using twine

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,7 @@ runs:
         echo "Publishing Pip package to pypi as ${PYPI_PUBLISH_USERNAME}:" &&
         twine upload
         -u "${PYPI_PUBLISH_USERNAME}" -p "${PYPI_PASSWORD}"
-        "${{ github.workspace }}/sdk/python/bin/dist/*.tar.gz"
+        "${{ github.workspace }}/sdk/python/bin/dist/*"
         --skip-existing
         --verbose
       shell: bash


### PR DESCRIPTION
Fixes #14 

There's no tests in this repo but we tested out the equivalent of this code in pulumi/scripts on multiple repositories including pulumi-kubernetes.

The context for this work is https://github.com/pulumi/home/issues/2883
