### PR TITLE
BREAKING Upgrade `actions/download-artifact` from v2 to v4

### DIFF
--- a/lang/dotnet/action.yml
+++ b/lang/dotnet/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         dotnet-version: ${{ env.DOTNETVERSION }}
     - name: Download dotnet SDK
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: dotnet-sdk.tar.gz
         path: ${{ github.workspace }}/sdk/

--- a/lang/java/action.yml
+++ b/lang/java/action.yml
@@ -15,7 +15,7 @@ runs:
       with:
         gradle-version: "7.6"
     - name: Download java SDK
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/

--- a/lang/nodejs/action.yml
+++ b/lang/nodejs/action.yml
@@ -10,7 +10,7 @@ runs:
         node-version: ${{ env.NODEVERSION }}
         registry-url: https://registry.npmjs.org
     - name: Download nodejs SDK
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: nodejs-sdk.tar.gz
         path: ${{ github.workspace }}/sdk/

--- a/lang/python/action.yml
+++ b/lang/python/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         python-version: ${{ env.PYTHONVERSION }}
     - name: Download python SDK
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: python-sdk.tar.gz
         path: ${{ github.workspace }}/sdk/


### PR DESCRIPTION
`actions/download-artifact@v4` requires artifacts that were uploaded with `actions/upload-artifact@v4`, so all consumers of this library must also upgrade.

This PR follows from https://github.com/pulumi/ci-mgmt/pull/818.