### PR TITLE
BREAKING CHANGE: Use explicit version for release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: 'Pulumi Package publisher'
 description: 'A GitHub Action that publishes provider SDKs'
 inputs:
+  version:
+    description: The version of the provider being published. If not provided, the version will be calculated by pulumi/provider-version-action@v1
+    required: false
   sdk:
     description: |
       The name of the language SDK being published.
@@ -32,12 +35,18 @@ inputs:
 #
 #    If (${LANGUAGE} or all (but not !all)) and not !${LANGUAGE}
 
+
 runs:
   using: "composite"
   steps:
     - name: Verify input
       run: echo 'Publishing SDK:' && echo ${{ inputs.sdk }}
       shell: bash
+    - name: Fetch version
+      if: inputs.version == ''
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PROVIDER_VERSION
     - name: Checkout Repo
       uses: actions/checkout@v3
       with:
@@ -82,3 +91,5 @@ runs:
     - name: Java - Publish to Maven
       if: (contains(inputs.sdk, 'java') || (contains(inputs.sdk, 'all') && !contains(inputs.sdk, '!all'))) && !contains(inputs.sdk, '!java')
       uses: ./.pulumi-package-publish/lang/java
+      env:
+        PROVIDER_VERSION: ${{ inputs.version || env.PROVIDER_VERSION }}

--- a/action.yml
+++ b/action.yml
@@ -42,9 +42,6 @@ runs:
       uses: actions/checkout@v3
       with:
         repository: ${{ github.repository }}
-    - name: Unshallow clone for tags
-      run: git fetch --prune --unshallow --tags
-      shell: bash
     - name: Install Go
       uses: actions/setup-go@v3
       with:
@@ -55,7 +52,6 @@ runs:
         repo: pulumi/pulumictl
     - name: Install Pulumi CLI
       uses: pulumi/action-install-pulumi-cli@v2
-
 
     # `uses:` statements do not support expressions
     # (https://github.com/actions/runner/issues/895), so this is invalid:

--- a/action.yml
+++ b/action.yml
@@ -2,8 +2,8 @@ name: 'Pulumi Package publisher'
 description: 'A GitHub Action that publishes provider SDKs'
 inputs:
   version:
-    description: The version of the provider being published. If not provided, the version will be calculated by pulumi/provider-version-action@v1
-    required: false
+    description: The version of the provider being published.
+    required: true
   sdk:
     description: |
       The name of the language SDK being published.
@@ -35,18 +35,12 @@ inputs:
 #
 #    If (${LANGUAGE} or all (but not !all)) and not !${LANGUAGE}
 
-
 runs:
   using: "composite"
   steps:
     - name: Verify input
       run: echo 'Publishing SDK:' && echo ${{ inputs.sdk }}
       shell: bash
-    - name: Fetch version
-      if: inputs.version == ''
-      uses: pulumi/provider-version-action@v1
-      with:
-        set-env: PROVIDER_VERSION
     - name: Checkout Repo
       uses: actions/checkout@v3
       with:
@@ -92,4 +86,4 @@ runs:
       if: (contains(inputs.sdk, 'java') || (contains(inputs.sdk, 'all') && !contains(inputs.sdk, '!all'))) && !contains(inputs.sdk, '!java')
       uses: ./.pulumi-package-publish/lang/java
       env:
-        PROVIDER_VERSION: ${{ inputs.version || env.PROVIDER_VERSION }}
+        PROVIDER_VERSION: ${{ inputs.version }}

--- a/lang/java/action.yml
+++ b/lang/java/action.yml
@@ -24,9 +24,9 @@ runs:
         ${{github.workspace}}/sdk/java
       shell: bash
     - name: Set PACKAGE_VERSION to Env
-      run: echo "PACKAGE_VERSION=$(pulumictl get version --language generic)" >>
-        $GITHUB_ENV
-      shell: bash
+      uses: pulumi/provider-version-action@v1
+      with:
+        set-env: PACKAGE_VERSION
     - name: Publish Java SDK
       continue-on-error: true
       uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49

--- a/lang/java/action.yml
+++ b/lang/java/action.yml
@@ -23,13 +23,11 @@ runs:
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
       shell: bash
-    - name: Set PACKAGE_VERSION to Env
-      uses: pulumi/provider-version-action@v1
-      with:
-        set-env: PACKAGE_VERSION
     - name: Publish Java SDK
       continue-on-error: true
       uses: gradle/gradle-build-action@9b814496b50909128c6a52622b416c5ffa04db49
+      env:
+        PACKAGE_VERSION: ${{ env.PROVIDER_VERSION }}
       with:
         arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository
         build-root-directory: ./sdk/java


### PR DESCRIPTION
This was missed as part of https://github.com/pulumi/ci-mgmt/pull/900

We no longer use pulumictl to re-calculate the version multiple times throughout a workflow. Instead, we use the `pulumi/provider-version-action` to calculate the version, and prefer passing the version around as an explicit variable to ensure it never gets changed.

The new version is slightly different to the one generated by pulumictl - using a shorthash of 7 characters rather than 8.

1. Add a new required input for `version` (BREAKING CHANGE).
2. Set the version input to the `PROVIDER_VERSION` which is the env name we use in all other jobs for the version of the _provider_ - for the SDK release sub-jobs which need it.
3. During the Java SDK publish sub-job, set the java-specific `PACKAGE_VERSION` env variable.

## Breaking Change Rational

We always reference the exact version of this action and we've made previous breaking changes, so it's better to avoid the complexity for backward compatibility as we'll need to update all call sites with the new version anyway.