### PR TITLE
Catch dotnet publish failures

### DIFF
--- a/lang/dotnet/action.yml
+++ b/lang/dotnet/action.yml
@@ -18,6 +18,6 @@ runs:
         ${{ github.workspace }}/sdk/dotnet
       shell: bash
     - name: Publish dotnet SDK
-      run: find "${{ github.workspace }}/sdk/dotnet/bin/Debug/" -name 'Pulumi.*.nupkg'
-        -exec dotnet nuget push -k "${NUGET_PUBLISH_KEY}" -s https://api.nuget.org/v3/index.json {} \;
+      run: find "${{ github.workspace }}/sdk/dotnet/bin/Debug/" -name 'Pulumi.*.nupkg' -print0 |
+        xargs -0 -I {} dotnet nuget push -k "${NUGET_PUBLISH_KEY}" -s https://api.nuget.org/v3/index.json {}
       shell: bash


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-package-publisher/issues/20

We were ignoring dotnet publish failures since find ... -exec does not fail on a failure in the exec command: https://serverfault.com/questions/905031/how-can-i-make-find-return-non-0-if-exec-command-fails

The workaround is to change it to find | xargs.

tested in https://github.com/pulumi/pulumi-random/pull/960

[ac5b002](https://github.com/pulumi/pulumi-random/pull/960/commits/ac5b002e052025be2f606e532b5367f31296831f) which has the old action and an invalid Nuget key but fails silently, marking the job as successful.

[dd34238](https://github.com/pulumi/pulumi-random/pull/960/commits/dd342384407209c626ed5a43463ad4a022989dae) has the action in this PR and an invalid key and correctly fails now.