### PR TITLE
Skip duplicate packages during publish step

### DIFF
--- a/lang/dotnet/action.yml
+++ b/lang/dotnet/action.yml
@@ -19,5 +19,5 @@ runs:
       shell: bash
     - name: Publish dotnet SDK
       run: find "${{ github.workspace }}/sdk/dotnet/bin/Debug/" -name 'Pulumi.*.nupkg' -print0 |
-        xargs -0 -I {} dotnet nuget push -k "${NUGET_PUBLISH_KEY}" -s https://api.nuget.org/v3/index.json {}
+        xargs -0 -I {} dotnet nuget push -k "${NUGET_PUBLISH_KEY}" -s https://api.nuget.org/v3/index.json --skip duplicate {}
       shell: bash


### PR DESCRIPTION
This will prevent `publish` from failing on rerun, if a different package in CI failed to publish.