### PR TITLE
Add assertPrerelease option to stop releases outside of release.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,12 @@ inputs:
   python-version:
     description: The version of Python being used in the provider
     required: true
+  assertPrerelease:
+    description: |
+      Assert that `version` argument describes a pre-release.
+
+      `assertPrerelease` should be set wherever you *do not* want to publish releases
+      from, like CI.
   sdk:
     description: |
       The name of the language SDK being published.
@@ -53,6 +59,14 @@ runs:
     - name: Verify input
       run: echo 'Publishing SDK:' && echo ${{ inputs.sdk }}
       shell: bash
+    - name: Assert pre-release
+      if: assertPrerelease
+      run: |
+        if [[ "${{ inputs.version }}" =~ "^v[0-9]+\.[0-9]+\.[0-9]+$" ]] then
+        	echo "It looks like you have attempted to publish a non-alpha release by accident."
+        	exit 1;
+        fi
+      shell: bash
     - name: Checkout Repo
       uses: actions/checkout@v3
       with:
@@ -88,22 +102,24 @@ runs:
     - name: Nodejs - Publish to NPM
       uses: ./.pulumi-package-publish/lang/nodejs
       if: (contains(inputs.sdk, 'nodejs') || (contains(inputs.sdk, 'all') && !contains(inputs.sdk, '!all'))) && !contains(inputs.sdk, '!nodejs')
-      env:
-        NODE_VERSTION: ${{ inputs.node-version }}
+      with:
+        version: ${{ inputs.version }}
+        node-version: ${{ inputs.node-version }}
     - name: .NET - Publish to Nuget
       if: (contains(inputs.sdk, 'dotnet') || (contains(inputs.sdk, 'all') && !contains(inputs.sdk, '!all'))) && !contains(inputs.sdk, '!dotnet')
       uses: ./.pulumi-package-publish/lang/dotnet
-      env:
-        DOTNET_VERSTION: ${{ inputs.dotnet-version }}
+      with:
+        version: ${{ inputs.version }}
+        dotnet-version: ${{ inputs.dotnet-version }}
     - name: Python - Publish to PyPi
       if: (contains(inputs.sdk, 'python') || (contains(inputs.sdk, 'all') && !contains(inputs.sdk, '!all'))) && !contains(inputs.sdk, '!python')
       uses: ./.pulumi-package-publish/lang/python
-      env:
-        PYTHON_VERSION: ${{ inputs.python-version }}
+      with:
+        version: ${{ inputs.version }}
+        python-version: ${{ inputs.python-version }}
     - name: Java - Publish to Maven
       if: (contains(inputs.sdk, 'java') || (contains(inputs.sdk, 'all') && !contains(inputs.sdk, '!all'))) && !contains(inputs.sdk, '!java')
       uses: ./.pulumi-package-publish/lang/java
-      env:
-        PROVIDER_VERSION: ${{ inputs.version }}
-        JAVA_VERSION: ${{ inputs.java-version }}
-
+      with:
+        version: ${{ inputs.version }}
+        java-version: ${{ inputs.java-version }}

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
       run: echo 'Publishing SDK:' && echo ${{ inputs.sdk }}
       shell: bash
     - name: Assert pre-release
-      if: assertPrerelease
+      if: inputs.assertPrerelease == "true"
       run: |
         if [[ "${{ inputs.version }}" =~ "^v[0-9]+\.[0-9]+\.[0-9]+$" ]] then
         	echo "It looks like you have attempted to publish a non-alpha release by accident."

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
       run: echo 'Publishing SDK:' && echo ${{ inputs.sdk }}
       shell: bash
     - name: Assert pre-release
-      if: inputs.assertPrerelease == "true"
+      if: ${{ inputs.assertPrerelease == "true" }}
       run: |
         if [[ "${{ inputs.version }}" =~ "^v[0-9]+\.[0-9]+\.[0-9]+$" ]] then
         	echo "It looks like you have attempted to publish a non-alpha release by accident."

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
       run: echo 'Publishing SDK:' && echo ${{ inputs.sdk }}
       shell: bash
     - name: Assert pre-release
-      if: ${{ inputs.assertPrerelease == "true" }}
+      if: ${{ inputs.assertPrerelease == 'true' }}
       run: |
         if [[ "${{ inputs.version }}" =~ "^v[0-9]+\.[0-9]+\.[0-9]+$" ]] then
         	echo "It looks like you have attempted to publish a non-alpha release by accident."

--- a/lang/dotnet/action.yml
+++ b/lang/dotnet/action.yml
@@ -1,5 +1,17 @@
 name: 'Publish to Nuget'
-description: 'A subcomponent of pulumi-package-publish'
+description: |
+  A subcomponent of pulumi-package-publish
+
+inputs:
+  version:
+    description: >-
+      The version of the provider being published.
+
+      TODO: Validate that the SDK we are publishing matches this input.
+    required: true
+  dotnet-version:
+    description: The version of Dotnet being used in the provider
+    required: true
 
 runs:
   using: "composite"
@@ -7,7 +19,7 @@ runs:
     - name: Setup DotNet
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
+        dotnet-version: ${{ inputs.dotnet-version }}
     - name: Download dotnet SDK
       uses: actions/download-artifact@v4
       with:

--- a/lang/java/action.yml
+++ b/lang/java/action.yml
@@ -1,5 +1,14 @@
 name: 'Publish to Maven'
-description: 'A subcomponent of pulumi-package-publish'
+description: |
+  A subcomponent of pulumi-package-publish
+
+inputs:
+  version:
+    description: The version of the provider being published.
+    required: true
+  java-version:
+    description: The version of Java being used in the provider
+    required: true
 
 runs:
   using: "composite"
@@ -9,7 +18,7 @@ runs:
       with:
         cache: gradle
         distribution: temurin
-        java-version: ${{ env.JAVA_VERSION }}
+        java-version: ${{ inputs.java-version }}
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       with:

--- a/lang/nodejs/action.yml
+++ b/lang/nodejs/action.yml
@@ -33,7 +33,7 @@ runs:
       # inputs.version). Otherwise we could publish a version that doesn't match what we
       # are trying to publish.
       run: >-
-        ACTUAL="v$(cat ${{ github.workspace }}/sdk/nodejs/bin/package.json | jq .version)" &&
+        ACTUAL="v$(cat ${{ github.workspace }}/sdk/nodejs/bin/package.json | jq .version --raw-output)" &&
         JS="$(pulumictl convert-version --version "${{ inputs.version }}" --language javascript)" &&
         if [[ "$ACTUAL" != "$JS" ]]; then
           echo "Found version $ACTUAL does not match expected version $JS";

--- a/lang/nodejs/action.yml
+++ b/lang/nodejs/action.yml
@@ -33,7 +33,7 @@ runs:
       # inputs.version). Otherwise we could publish a version that doesn't match what we
       # are trying to publish.
       run: >-
-        ACTUAL="$(cat ${{ github.workspace }}/sdk/nodejs/bin/package.json | jq .version)" &&
+        ACTUAL="v$(cat ${{ github.workspace }}/sdk/nodejs/bin/package.json | jq .version)" &&
         JS="$(pulumictl convert-version --version "${{ inputs.version }}" --language javascript)" &&
         if [[ "$ACTUAL" != "$JS" ]]; then
           echo "Found version $ACTUAL does not match expected version $JS";

--- a/lang/nodejs/action.yml
+++ b/lang/nodejs/action.yml
@@ -1,13 +1,34 @@
 name: 'Publish to NPM'
-description: 'A subcomponent of pulumi-package-publish'
+description: |
+  A subcomponent of pulumi-package-publish
+
+inputs:
+  version:
+    description: The version of the provider being published.
+    required: true
+  node-version:
+    description: The version of Node being used in the provider
+    required: true
 
 runs:
   using: "composite"
   steps:
+    - name: Validate Package Version
+      shell: bash
+      # Ensure that we are publishing only the version that we expect (and that is set in
+      # inputs.version). Otherwise we could publish a version that doesn't match what we
+      # are trying to publish.
+      run: >-
+        ACTUAL="$(cat ${{ github.workspace }}/sdk/nodejs/bin/package.json | jq .version)" &&
+        JS=$(pulumictl convert-version --version "${{ inputs.version }} --language javascript &&
+        if [[ "$ACTUAL" != "$JS" ]]; then
+          echo "Found version $ACTUAL does not match expected version $JS";
+          exit 1;
+        fi
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ env.NODE_VERSION }}
+        node-version: ${{ inputs.node-version }}
         registry-url: https://registry.npmjs.org
     - name: Download nodejs SDK
       uses: actions/download-artifact@v4

--- a/lang/nodejs/action.yml
+++ b/lang/nodejs/action.yml
@@ -20,7 +20,7 @@ runs:
       # are trying to publish.
       run: >-
         ACTUAL="$(cat ${{ github.workspace }}/sdk/nodejs/bin/package.json | jq .version)" &&
-        JS=$(pulumictl convert-version --version "${{ inputs.version }} --language javascript &&
+        JS="$(pulumictl convert-version --version "${{ inputs.version }}" --language javascript)" &&
         if [[ "$ACTUAL" != "$JS" ]]; then
           echo "Found version $ACTUAL does not match expected version $JS";
           exit 1;

--- a/lang/nodejs/action.yml
+++ b/lang/nodejs/action.yml
@@ -13,18 +13,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Validate Package Version
-      shell: bash
-      # Ensure that we are publishing only the version that we expect (and that is set in
-      # inputs.version). Otherwise we could publish a version that doesn't match what we
-      # are trying to publish.
-      run: >-
-        ACTUAL="$(cat ${{ github.workspace }}/sdk/nodejs/bin/package.json | jq .version)" &&
-        JS="$(pulumictl convert-version --version "${{ inputs.version }}" --language javascript)" &&
-        if [[ "$ACTUAL" != "$JS" ]]; then
-          echo "Found version $ACTUAL does not match expected version $JS";
-          exit 1;
-        fi
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
@@ -39,6 +27,18 @@ runs:
       run: tar -zxf ${{ github.workspace }}/sdk/nodejs.tar.gz -C
         ${{ github.workspace }}/sdk/nodejs
       shell: bash
+    - name: Validate Package Version
+      shell: bash
+      # Ensure that we are publishing only the version that we expect (and that is set in
+      # inputs.version). Otherwise we could publish a version that doesn't match what we
+      # are trying to publish.
+      run: >-
+        ACTUAL="$(cat ${{ github.workspace }}/sdk/nodejs/bin/package.json | jq .version)" &&
+        JS="$(pulumictl convert-version --version "${{ inputs.version }}" --language javascript)" &&
+        if [[ "$ACTUAL" != "$JS" ]]; then
+          echo "Found version $ACTUAL does not match expected version $JS";
+          exit 1;
+        fi
     - name: Run npm whoami
       run: npm whoami
       shell: bash

--- a/lang/python/action.yml
+++ b/lang/python/action.yml
@@ -1,5 +1,17 @@
 name: 'Publish to PyPi'
-description: 'A subcomponent of pulumi-package-publish'
+description: |
+  A subcomponent of pulumi-package-publish
+
+inputs:
+  version:
+    description: >-
+      The version of the provider being published.
+
+      TODO: Validate that the SDK we are publishing matches this input.
+    required: true
+  python-version:
+    description: The version of Python being used in the provider
+    required: true
 
 runs:
   using: "composite"
@@ -7,7 +19,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ env.PYTHON_VERSION }}
+        python-version: ${{ inputs.python-version }}
     - name: Download python SDK
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
We accidentally releases one of our providers
[artifactory](https://github.com/pulumi/pulumi-artifactory/actions/runs/9451955578/job/26035510190) by merging into `main` (without running the release workflow). This left the provider in an invalid state, since `main` did not publish a release provider binary, but it did publish a release SDK.

The solution is to prevent publishing release SDKs in any workflow besides `release.yml`.

As a follow up, I will add `assertPrerelease: true` to all workflows except `release.yml`.