### PR TITLE
Fixes .NET's `--skip-duplicate` flag (from `--skip duplicate`)

### DIFF
--- a/lang/dotnet/action.yml
+++ b/lang/dotnet/action.yml
@@ -31,5 +31,5 @@ runs:
       shell: bash
     - name: Publish dotnet SDK
       run: find "${{ github.workspace }}/sdk/dotnet/bin/Debug/" -name 'Pulumi.*.nupkg' -print0 |
-        xargs -0 -I {} dotnet nuget push -k "${NUGET_PUBLISH_KEY}" -s https://api.nuget.org/v3/index.json --skip duplicate {}
+        xargs -0 -I {} dotnet nuget push -k "${NUGET_PUBLISH_KEY}" -s https://api.nuget.org/v3/index.json --skip-duplicate {}
       shell: bash


### PR DESCRIPTION
`--skip duplicate` was added in https://github.com/pulumi/pulumi-package-publisher/pull/29 and never released.