### PR TITLE
BREAKING: Remove installing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,13 @@ Set the following environment variables in your Workflow and your GitHub Action 
 
 ```yaml
 env:
-    DOTNETVERSION: |
-    6.0.x
-    3.1.301
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    GOVERSION: 1.20.1
-    JAVAVERSION: "11"
-    NODEVERSION: 16.x
     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
     PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-    PYTHONVERSION: "3.9"
     SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
     SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
     SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
-    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
 
 ### Use

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # pulumi-package-publisher
+
 A composite action for publishing Pulumi packages
 
 _This Action is currently in preview and meant for internal use. Any functionality can and likely will change._
 
 ### Purpose
+
 This Action automates setup and publication to the package registries of four Pulumi languages.
 
 ### Setup
+
+Ensure the following tools are installed:
+
+- Pulumi CLI
+- Go
+- Node.js
+- Python
+- Java (and Gradle)
 
 Set the following environment variables in your Workflow and your GitHub Action secrets:
 
@@ -32,6 +42,7 @@ env:
 ### Use
 
 Add this action to your Workflow as a step to publish to all four supported registries:
+
 - PyPI
 - Maven
 - npm

--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@ This Action automates setup and publication to the package registries of four Pu
 Ensure the following tools are installed:
 
 - Pulumi CLI
+- pulumictl
 - Go
 - Node.js
 - Python
 - Java (and Gradle)
+
+It's expected that the repository is checked out.
 
 Set the following environment variables in your Workflow and your GitHub Action secrets:
 

--- a/action.yml
+++ b/action.yml
@@ -55,16 +55,6 @@ runs:
         	exit 1;
         fi
       shell: bash
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-      with:
-        repository: ${{ github.repository }}
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Install Pulumi CLI
-      uses: pulumi/action-install-pulumi-cli@v2
 
     # `uses:` statements do not support expressions
     # (https://github.com/actions/runner/issues/895), so this is invalid:

--- a/action.yml
+++ b/action.yml
@@ -4,18 +4,6 @@ inputs:
   version:
     description: The version of the provider being published.
     required: true
-  dotnet-version:
-    description: The version of Dotnet being used in the provider
-    required: true
-  java-version:
-    description: The version of Java being used in the provider
-    required: true
-  node-version:
-    description: The version of Node being used in the provider
-    required: true
-  python-version:
-    description: The version of Python being used in the provider
-    required: true
   assertPrerelease:
     description: |
       Assert that `version` argument describes a pre-release.
@@ -71,10 +59,6 @@ runs:
       uses: actions/checkout@v3
       with:
         repository: ${{ github.repository }}
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ env.GOVERSION }}
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.5.0
       with:
@@ -104,22 +88,18 @@ runs:
       if: (contains(inputs.sdk, 'nodejs') || (contains(inputs.sdk, 'all') && !contains(inputs.sdk, '!all'))) && !contains(inputs.sdk, '!nodejs')
       with:
         version: ${{ inputs.version }}
-        node-version: ${{ inputs.node-version }}
     - name: .NET - Publish to Nuget
       if: (contains(inputs.sdk, 'dotnet') || (contains(inputs.sdk, 'all') && !contains(inputs.sdk, '!all'))) && !contains(inputs.sdk, '!dotnet')
       uses: ./.pulumi-package-publish/lang/dotnet
       with:
         version: ${{ inputs.version }}
-        dotnet-version: ${{ inputs.dotnet-version }}
     - name: Python - Publish to PyPi
       if: (contains(inputs.sdk, 'python') || (contains(inputs.sdk, 'all') && !contains(inputs.sdk, '!all'))) && !contains(inputs.sdk, '!python')
       uses: ./.pulumi-package-publish/lang/python
       with:
         version: ${{ inputs.version }}
-        python-version: ${{ inputs.python-version }}
     - name: Java - Publish to Maven
       if: (contains(inputs.sdk, 'java') || (contains(inputs.sdk, 'all') && !contains(inputs.sdk, '!all'))) && !contains(inputs.sdk, '!java')
       uses: ./.pulumi-package-publish/lang/java
       with:
         version: ${{ inputs.version }}
-        java-version: ${{ inputs.java-version }}

--- a/lang/dotnet/action.yml
+++ b/lang/dotnet/action.yml
@@ -9,17 +9,10 @@ inputs:
 
       TODO: Validate that the SDK we are publishing matches this input.
     required: true
-  dotnet-version:
-    description: The version of Dotnet being used in the provider
-    required: true
 
 runs:
   using: "composite"
   steps:
-    - name: Setup DotNet
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: ${{ inputs.dotnet-version }}
     - name: Download dotnet SDK
       uses: actions/download-artifact@v4
       with:

--- a/lang/java/action.yml
+++ b/lang/java/action.yml
@@ -6,23 +6,10 @@ inputs:
   version:
     description: The version of the provider being published.
     required: true
-  java-version:
-    description: The version of Java being used in the provider
-    required: true
 
 runs:
   using: "composite"
   steps:
-    - name: Setup Java
-      uses: actions/setup-java@v3
-      with:
-        cache: gradle
-        distribution: temurin
-        java-version: ${{ inputs.java-version }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: "7.6"
     - name: Download java SDK
       uses: actions/download-artifact@v4
       with:

--- a/lang/nodejs/action.yml
+++ b/lang/nodejs/action.yml
@@ -6,18 +6,10 @@ inputs:
   version:
     description: The version of the provider being published.
     required: true
-  node-version:
-    description: The version of Node being used in the provider
-    required: true
 
 runs:
   using: "composite"
   steps:
-    - name: Setup Node
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ inputs.node-version }}
-        registry-url: https://registry.npmjs.org
     - name: Download nodejs SDK
       uses: actions/download-artifact@v4
       with:

--- a/lang/python/action.yml
+++ b/lang/python/action.yml
@@ -9,17 +9,10 @@ inputs:
 
       TODO: Validate that the SDK we are publishing matches this input.
     required: true
-  python-version:
-    description: The version of Python being used in the provider
-    required: true
 
 runs:
   using: "composite"
   steps:
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ inputs.python-version }}
     - name: Download python SDK
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
Leave it to the caller to install the prerequisite tools as additional options might want to be used for caching etc.

- Remove tool install steps.
- Remove step to check out repository.
- Remove all version inputs.
- Add tool pre-requisites to the documentation.

The other half of the work to integrate this breaking change into ci-mgmt is in:
- https://github.com/pulumi/ci-mgmt/pull/1004