### PR TITLE
All actions attempt to create directories before using

### DIFF
--- a/lang/dotnet/action.yml
+++ b/lang/dotnet/action.yml
@@ -19,7 +19,7 @@ runs:
         name: dotnet-sdk.tar.gz
         path: ${{ github.workspace }}/sdk/
     - name: Uncompress dotnet SDK
-      run: tar -zxf ${{ github.workspace }}/sdk/dotnet.tar.gz -C
+      run: mkdir -p ${{ github.workspace }}/sdk/dotnet && tar -zxf ${{ github.workspace }}/sdk/dotnet.tar.gz -C
         ${{ github.workspace }}/sdk/dotnet
       shell: bash
     - name: Publish dotnet SDK

--- a/lang/java/action.yml
+++ b/lang/java/action.yml
@@ -19,7 +19,7 @@ runs:
         name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
+      run: mkdir -p ${{ github.workspace }}/sdk/java && tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
         ${{github.workspace}}/sdk/java
       shell: bash
     - name: Publish Java SDK

--- a/lang/nodejs/action.yml
+++ b/lang/nodejs/action.yml
@@ -16,7 +16,7 @@ runs:
         name: nodejs-sdk.tar.gz
         path: ${{ github.workspace }}/sdk/
     - name: Uncompress nodejs SDK
-      run: tar -zxf ${{ github.workspace }}/sdk/nodejs.tar.gz -C
+      run: mkdir -p ${{ github.workspace }}/sdk/nodejs && tar -zxf ${{ github.workspace }}/sdk/nodejs.tar.gz -C
         ${{ github.workspace }}/sdk/nodejs
       shell: bash
     - name: Validate Package Version

--- a/lang/python/action.yml
+++ b/lang/python/action.yml
@@ -19,7 +19,7 @@ runs:
         name: python-sdk.tar.gz
         path: ${{ github.workspace }}/sdk/
     - name: Uncompress python SDK
-      run: tar -zxf ${{ github.workspace }}/sdk/python.tar.gz -C
+      run: mkdir -p ${{ github.workspace }}/sdk/python && tar -zxf ${{ github.workspace }}/sdk/python.tar.gz -C
         ${{ github.workspace }}/sdk/python
       shell: bash
     - name: Install Twine


### PR DESCRIPTION
We are no longer going to be checking in non-golang SDKs into source control. As a result of this directories that were guaranteed to exist before need to be created before unpacking files into them.